### PR TITLE
Update reference scripts to use proper fastqc version

### DIFF
--- a/day03/scripts/.day3_solution_part1.sbatch
+++ b/day03/scripts/.day3_solution_part1.sbatch
@@ -2,10 +2,14 @@
 #SBATCH --output=/scratch/Users/zmaas/workshop-day3/e_and_o/%x_%j.out
 #SBATCH --error=/scratch/Users/zmaas/workshop-day3/e_and_o/%x_%j.err
 #SBATCH --mail-user=zachary.maas@colorado.edu
-#SBATCH -p short
+#SBATCH -p compute
 #SBATCH -N 1
 #SBATCH -c 1
-#SBATCH --mem=256mb
+#SBATCH --mem=256Mb
 
+# Make the directory if it doesn't exist, -p won't complain if it does
+mkdir -p /scratch/Users/zmaas/workshop-day3/data
+# Change into the directory
 cd /scratch/Users/zmaas/workshop-day3/data
+# Download our data
 wget -c ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/data/HG00096/sequence_read/SRR062641.filt.fastq.gz

--- a/day03/scripts/.day3_solution_part2.sbatch
+++ b/day03/scripts/.day3_solution_part2.sbatch
@@ -2,11 +2,14 @@
 #SBATCH --output=/scratch/Users/zmaas/workshop-day3/e_and_o/%x_%j.out
 #SBATCH --error=/scratch/Users/zmaas/workshop-day3/e_and_o/%x_%j.err
 #SBATCH --mail-user=zachary.maas@colorado.edu
-#SBATCH -p short
+#SBATCH -p compute
 #SBATCH -N 1
 #SBATCH -c 1
-#SBATCH --mem=256mb
+#SBATCH --mem=256Mb
 
-module load fastqc
+# Load our module in the proper version
+module load fastqc/0.11.5
+# Change to our data directory
 cd /scratch/Users/zmaas/workshop-day3/data
+# Run fastqc on the file we downloaded
 fastqc SRR062641.filt.fastq.gz


### PR DESCRIPTION
This is a quick fix to make sure we're using the proper version of fastqc in the reference scripts provided to students after the class.